### PR TITLE
Add newrelic extension for php 7.4 to 8.1

### DIFF
--- a/Formula/newrelic@7.4.rb
+++ b/Formula/newrelic@7.4.rb
@@ -1,0 +1,54 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+# Class for Newrelic Extension
+class NewrelicAT74 < AbstractPhpExtension
+  init
+  desc "Newrelic PHP extension"
+  homepage "https://github.com/newrelic/newrelic-php-agent"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.4.0.316.tar.gz"
+  version "v10.4.0.316"
+  sha256 "84eee1791051dafbad6627134dd052cc89e6611b175fda7808a65786938591b3"
+  head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
+  license "Apache-2.0"
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/extensions"
+  end
+
+  # for pcre_compile
+  depends_on "pcre"
+
+  # for aclocal + glibtoolize
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  # for the daemon
+  depends_on "go" => :build
+
+  def config_file_content
+    <<~EOS
+      [#{extension}]
+      #{extension_type}="#{module_path}"
+      newrelic.daemon.location="#{prefix}/daemon"
+      newrelic.daemon.address="/tmp/.newrelic80.sock"
+      newrelic.daemon.port="/tmp/.newrelic80.sock"
+      newrelic.logfile="/var/log/newrelic_php_agent.log"
+      newrelic.daemon.logfile="/var/log/newrelic_daemon.log"
+    EOS
+  rescue error
+    raise error
+  end
+
+  def install
+    inreplace "agent/php_autorum.c", "return (char*)emalloc(len);", "return (char*)emalloc((unsigned)len);"
+    inreplace "axiom/Makefile", "AXIOM_CFLAGS += -Wimplicit-fallthrough", "#AXIOM_CFLAGS += -Wimplicit-fallthrough"
+    system "make", "daemon"
+    system "make", "agent"
+    prefix.install "agent/modules/#{extension}.so"
+    prefix.install "bin/daemon"
+    write_config_file
+  end
+end

--- a/Formula/newrelic@8.0.rb
+++ b/Formula/newrelic@8.0.rb
@@ -1,0 +1,54 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+# Class for Newrelic Extension
+class NewrelicAT80 < AbstractPhpExtension
+  init
+  desc "Newrelic PHP extension"
+  homepage "https://github.com/newrelic/newrelic-php-agent"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.4.0.316.tar.gz"
+  version "v10.4.0.316"
+  sha256 "84eee1791051dafbad6627134dd052cc89e6611b175fda7808a65786938591b3"
+  head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
+  license "Apache-2.0"
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/extensions"
+  end
+
+  # for pcre_compile
+  depends_on "pcre"
+
+  # for aclocal + glibtoolize
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  # for the daemon
+  depends_on "go" => :build
+
+  def config_file_content
+    <<~EOS
+      [#{extension}]
+      #{extension_type}="#{module_path}"
+      newrelic.daemon.location="#{prefix}/daemon"
+      newrelic.daemon.address="/tmp/.newrelic80.sock"
+      newrelic.daemon.port="/tmp/.newrelic80.sock"
+      newrelic.logfile="/var/log/newrelic_php_agent.log"
+      newrelic.daemon.logfile="/var/log/newrelic_daemon.log"
+    EOS
+  rescue error
+    raise error
+  end
+
+  def install
+    inreplace "agent/php_autorum.c", "return (char*)emalloc(len);", "return (char*)emalloc((unsigned)len);"
+    inreplace "axiom/Makefile", "AXIOM_CFLAGS += -Wimplicit-fallthrough", "#AXIOM_CFLAGS += -Wimplicit-fallthrough"
+    system "make", "daemon"
+    system "make", "agent"
+    prefix.install "agent/modules/#{extension}.so"
+    prefix.install "bin/daemon"
+    write_config_file
+  end
+end

--- a/Formula/newrelic@8.1.rb
+++ b/Formula/newrelic@8.1.rb
@@ -1,0 +1,54 @@
+# typed: false
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+# Class for Newrelic Extension
+class NewrelicAT81 < AbstractPhpExtension
+  init
+  desc "Newrelic PHP extension"
+  homepage "https://github.com/newrelic/newrelic-php-agent"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.4.0.316.tar.gz"
+  version "v10.4.0.316"
+  sha256 "84eee1791051dafbad6627134dd052cc89e6611b175fda7808a65786938591b3"
+  head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
+  license "Apache-2.0"
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/extensions"
+  end
+
+  # for pcre_compile
+  depends_on "pcre"
+
+  # for aclocal + glibtoolize
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  # for the daemon
+  depends_on "go" => :build
+
+  def config_file_content
+    <<~EOS
+      [#{extension}]
+      #{extension_type}="#{module_path}"
+      newrelic.daemon.location="#{prefix}/daemon"
+      newrelic.daemon.address="/tmp/.newrelic81.sock"
+      newrelic.daemon.port="/tmp/.newrelic81.sock"
+      newrelic.logfile="/var/log/newrelic_php_agent.log"
+      newrelic.daemon.logfile="/var/log/newrelic_daemon.log"
+    EOS
+  rescue error
+    raise error
+  end
+
+  def install
+    inreplace "agent/php_autorum.c", "return (char*)emalloc(len);", "return (char*)emalloc((unsigned)len);"
+    inreplace "axiom/Makefile", "AXIOM_CFLAGS += -Wimplicit-fallthrough", "#AXIOM_CFLAGS += -Wimplicit-fallthrough"
+    system "make", "daemon"
+    system "make", "agent"
+    prefix.install "agent/modules/#{extension}.so"
+    prefix.install "bin/daemon"
+    write_config_file
+  end
+end

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 | `memcached`  | `PHP 5.6` to `PHP 8.3` |
 | `mongodb`    | `PHP 5.6` to `PHP 8.3` |
 | `msgpack`    | `PHP 5.6` to `PHP 8.3` |
+| `newrelic`   | `PHP 7.4` to `PHP 8.1` |
 | `pcov`       | `PHP 7.1` to `PHP 8.3` |
 | `pdo_sqlsrv` | `PHP 7.0` to `PHP 8.3` |
 | `pecl_http`  | `PHP 5.6` to `PHP 8.3` |
@@ -243,6 +244,7 @@ This project is also generously supported by many other users and organisations 
 - [xdebug/xdebug](https://github.com/xdebug/xdebug "Xdebug")
 - [xlswriter](https://github.com/viest/php-ext-xlswriter.git "xlswriter")
 - [zeromq/php-zmq](https://github.com/zeromq/php-zmq "ZMQ")
+- [newrelic/newrelic-php-agent](https://github.com/newrelic/newrelic-php-agent "newrelic")
 
 ### Homebrew
 


### PR DESCRIPTION
---
name: 🎉 Add newrelic extension
about: For a project we need newrelic also available locally
labels: enhancement

---


### Description

It adds the newrelic.so extension for php 7.4 till 8.1 (the 8.2 is not available, yet). As newrelic requires a deamon available, it will create a socket for each version suffixed with the version (e.g. `/tmp/.newrelic81.sock`).

The resulting `/opt/homebrew/etc/php/8.1/conf.d/20-newrelic.ini` looks like this:

```
[newrelic]
extension="/opt/homebrew/opt/newrelic@8.1/newrelic.so"
newrelic.daemon.location="/opt/homebrew/Cellar/newrelic@8.1/v10.4.0.316/daemon"
newrelic.daemon.address="/tmp/.newrelic80.sock"
newrelic.daemon.port="/tmp/.newrelic80.sock"
newrelic.logfile="/var/log/newrelic_php_agent.log"
newrelic.daemon.logfile="/var/log/newrelic_daemon.log"
```

And the `php -i | grep newrelic` looks like this:

```
/opt/homebrew/etc/php/8.1/conf.d/20-newrelic.ini,
newrelic
newrelic.daemon.address => /tmp/.newrelic81.sock
newrelic.daemon.app_connect_timeout => no value
newrelic.daemon.app_timeout => no value
newrelic.daemon.auditlog => no value
newrelic.daemon.collector_host => no value
newrelic.daemon.dont_launch => no value
newrelic.daemon.location => /opt/homebrew/Cellar/newrelic@8.1/v10.4.0.316/daemon
newrelic.daemon.logfile => /var/log/newrelic_daemon.log
newrelic.daemon.loglevel => no value
newrelic.daemon.pidfile => no value
newrelic.daemon.port => /tmp/.newrelic81.sock
newrelic.daemon.proxy => no value
newrelic.daemon.ssl_ca_bundle => no value
newrelic.daemon.ssl_ca_path => no value
newrelic.daemon.start_timeout => no value
newrelic.daemon.utilization.detect_aws => enabled
newrelic.daemon.utilization.detect_azure => enabled
newrelic.daemon.utilization.detect_docker => enabled
newrelic.daemon.utilization.detect_gcp => enabled
newrelic.daemon.utilization.detect_kubernetes => enabled
newrelic.daemon.utilization.detect_pcf => enabled
newrelic.feature_flag => no value
newrelic.high_security => 0
newrelic.logfile => /var/log/newrelic_php_agent.log
newrelic.loglevel => info
newrelic.preload_framework_library_detection => 1
newrelic.transaction_tracer.internal_functions_enabled => disabled
newrelic.allow_raw_exception_messages => 1 => 1
newrelic.analytics_events.capture_attributes => enabled => enabled
newrelic.analytics_events.enabled => enabled => enabled
newrelic.application_logging.enabled => enabled => enabled
newrelic.application_logging.forwarding.enabled => enabled => enabled
newrelic.application_logging.forwarding.log_level => WARNING => WARNING
newrelic.application_logging.forwarding.max_samples_stored => 10000 => 10000
newrelic.application_logging.metrics.enabled => enabled => enabled
newrelic.appname => PHP Application => PHP Application
newrelic.attributes.enabled => enabled => enabled
newrelic.attributes.exclude => no value => no value
newrelic.attributes.include => no value => no value
newrelic.browser_monitoring.attributes.enabled => disabled => disabled
newrelic.browser_monitoring.attributes.exclude => no value => no value
newrelic.browser_monitoring.attributes.include => no value => no value
newrelic.browser_monitoring.auto_instrument => enabled => enabled
newrelic.browser_monitoring.capture_attributes => disabled => disabled
newrelic.browser_monitoring.debug => disabled => disabled
newrelic.browser_monitoring.loader => rum => rum
newrelic.capture_params => off => off
newrelic.code_level_metrics.enabled => disabled => disabled
newrelic.cross_application_tracer.enabled => disabled => disabled
newrelic.custom_events.max_samples_stored => 30000 => 30000
newrelic.custom_insights_events.enabled => enabled => enabled
newrelic.custom_parameters_enabled => 1 => 1
newrelic.datastore_tracer.database_name_reporting.enabled => enabled => enabled
newrelic.datastore_tracer.instance_reporting.enabled => enabled => enabled
newrelic.distributed_tracing_enabled => 1 => 1
newrelic.distributed_tracing_exclude_newrelic_header => 0 => 0
newrelic.enabled => yes => yes
newrelic.error_collector.attributes.enabled => enabled => enabled
newrelic.error_collector.attributes.exclude => no value => no value
newrelic.error_collector.attributes.include => no value => no value
newrelic.error_collector.capture_attributes => enabled => enabled
newrelic.error_collector.capture_events => enabled => enabled
newrelic.error_collector.enabled => enabled => enabled
newrelic.error_collector.ignore_errors => no value => no value
newrelic.error_collector.ignore_exceptions => no value => no value
newrelic.error_collector.ignore_user_exception_handler => no => no
newrelic.error_collector.prioritize_api_errors => no => no
newrelic.error_collector.record_database_errors => yes => yes
newrelic.framework => auto-detect => auto-detect
newrelic.framework.drupal.modules => on => on
newrelic.framework.wordpress.hooks => on => on
newrelic.framework.wordpress.hooks_skip_filename => no value => no value
newrelic.guzzle.enabled => 1 => 1
newrelic.ignored_params => no value => no value
newrelic.infinite_tracing.span_events.agent_queue.size => 1000 => 1000
newrelic.infinite_tracing.span_events.agent_queue.timeout => 1s => 1s
newrelic.infinite_tracing.span_events.queue_size => 100000 => 100000
newrelic.infinite_tracing.trace_observer.host => no value => no value
newrelic.infinite_tracing.trace_observer.port => 443 => 443
newrelic.labels => no value => no value
newrelic.license => ***INVALID FORMAT*** => ***INVALID FORMAT***
newrelic.phpunit_events.enabled => disabled => disabled
newrelic.process_host.display_name => no value => no value
newrelic.security_policies_token => no value => no value
newrelic.span_events.attributes.enabled => enabled => enabled
newrelic.span_events.attributes.exclude => no value => no value
newrelic.span_events.attributes.include => no value => no value
newrelic.span_events.max_samples_stored => 2000 => 2000
newrelic.span_events_enabled => 1 => 1
newrelic.special.max_nesting_level => -1 => -1
newrelic.synthetics.enabled => enabled => enabled
newrelic.transaction_events.attributes.enabled => enabled => enabled
newrelic.transaction_events.attributes.exclude => no value => no value
newrelic.transaction_events.attributes.include => no value => no value
newrelic.transaction_events.enabled => enabled => enabled
newrelic.transaction_tracer.attributes.enabled => enabled => enabled
newrelic.transaction_tracer.attributes.exclude => no value => no value
newrelic.transaction_tracer.attributes.include => no value => no value
newrelic.transaction_tracer.capture_attributes => enabled => enabled
newrelic.transaction_tracer.custom => no value => no value
newrelic.transaction_tracer.detail => 1 => 1
newrelic.transaction_tracer.enabled => enabled => enabled
newrelic.transaction_tracer.explain_enabled => enabled => enabled
newrelic.transaction_tracer.explain_threshold => 500 => 500
newrelic.transaction_tracer.gather_input_queries => 1 => 1
newrelic.transaction_tracer.max_segments_cli => 100000 => 100000
newrelic.transaction_tracer.max_segments_web => 0 => 0
newrelic.transaction_tracer.record_sql => obfuscated => obfuscated
newrelic.transaction_tracer.slow_sql => enabled => enabled
newrelic.transaction_tracer.stack_trace_threshold => 500 => 500
newrelic.transaction_tracer.threshold => apdex_f => apdex_f
newrelic.webtransaction.name.files => no value => no value
newrelic.webtransaction.name.functions => no value => no value
newrelic.webtransaction.name.remove_trailing_path => no => no
```
