### PR TITLE
Add phalcon5@8.3

### DIFF
--- a/Formula/phalcon5@8.3.rb
+++ b/Formula/phalcon5@8.3.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+# Class for Phalcon5 Extension
+class Phalcon5AT83 < AbstractPhpExtension
+  init
+  desc "Phalcon5 PHP extension"
+  homepage "https://github.com/phalcon/cphalcon"
+  url "https://pecl.php.net/get/phalcon-5.5.0.tgz"
+  sha256 "cb68e8c4d082b0e3c4d0ee3d108d68dbc93880a7a581c4c492070a345f2226c3"
+  head "https://github.com/phalcon/cphalcon.git", branch: "master"
+  license "BSD-3-Clause"
+
+  bottle do
+    root_url "https://ghcr.io/v2/shivammathur/extensions"
+  end
+
+  depends_on "pcre"
+
+  def install
+    Dir.chdir "phalcon-#{version}"
+    safe_phpize
+    system "./configure", "--prefix=#{prefix}", phpconfig, "--enable-phalcon"
+    system "make"
+    prefix.install "modules/#{extension}.so"
+    write_config_file
+    add_include_files
+  end
+end

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 | `pecl_http`     | `PHP 5.6` to `PHP 8.4` |
 | `phalcon3`      | `PHP 5.6` to `PHP 7.3` |
 | `phalcon4`      | `PHP 7.2` to `PHP 7.4` |
-| `phalcon5`      | `PHP 7.4` to `PHP 8.2` |
+| `phalcon5`      | `PHP 7.4` to `PHP 8.3` |
 | `propro`        | `PHP 5.6` to `PHP 7.4` |
 | `protobuf`      | `PHP 5.6` to `PHP 8.4` |
 | `psr`           | `PHP 5.6` to `PHP 8.4` |


### PR DESCRIPTION
---
name: 🎉 New Feature
about: Add phalcon5 extension for PHP 8.3
labels: bug or enhancement

---

### Description

This PR adds phalcon5 extension for PHP 8.3.

PECL: https://pecl.php.net/package/phalcon/5.5.0
