### PR TITLE
NewRelic PHP agent version update & added support for 8.4

### DIFF
--- a/Formula/newrelic@7.4.rb
+++ b/Formula/newrelic@7.4.rb
@@ -16,13 +16,6 @@ class NewrelicAT74 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_ventura:  "1efb6d11ee54e172e227e95326ee98ec537a0afa4cb2bf6af1cbdda3909d8756"
-    sha256 cellar: :any,                 arm64_monterey: "5529686047440f3398748541a3c6aead8b9ce3b7802fba657e56f1b6e974a5f1"
-    sha256 cellar: :any,                 arm64_big_sur:  "cf86a0607e58b9953f5cbbf902fb8a0a3eab333aaa90e7fc0a6f312215526a9a"
-    sha256 cellar: :any,                 ventura:        "7e2691d6662c1e68b8ba19cf940b83c321001031b5cb346d58173757875c0460"
-    sha256 cellar: :any,                 monterey:       "f6371a241492b7e86b15b786a55abb695f9abc9c4ed6c58d09e118a2b7381422"
-    sha256 cellar: :any,                 big_sur:        "7dc2a7dccbfb9bd9c0c4afc2578e27ece5563806f0903c5184a219311c0c4860"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a0beea57b29ba017347980c49be711f51002b551beb56fdbb83f1e131a7df06"
   end
 
   # for pcre_compile

--- a/Formula/newrelic@7.4.rb
+++ b/Formula/newrelic@7.4.rb
@@ -8,9 +8,9 @@ class NewrelicAT74 < AbstractPhpExtension
   init
   desc "Newrelic PHP extension"
   homepage "https://github.com/newrelic/newrelic-php-agent"
-  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.4.0.316.tar.gz"
-  version "v10.4.0.316"
-  sha256 "84eee1791051dafbad6627134dd052cc89e6611b175fda7808a65786938591b3"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v11.0.0.13.tar.gz"
+  version "v11.0.0.13"
+  sha256 "69f72541acf03e63a4d7d4a1053857b009279d1c526c9b68ed1338670a9e2cc0"
   head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
   license "Apache-2.0"
 
@@ -50,7 +50,7 @@ class NewrelicAT74 < AbstractPhpExtension
   end
 
   def install
-    inreplace "agent/php_autorum.c", "return (char*)emalloc(len);", "return (char*)emalloc((unsigned)len);"
+    inreplace "agent/config.m4", "-l:libprotobuf-c.a", "-lprotobuf-c"
     inreplace "axiom/Makefile", "AXIOM_CFLAGS += -Wimplicit-fallthrough", "#AXIOM_CFLAGS += -Wimplicit-fallthrough"
     system "make", "daemon"
     system "make", "agent"

--- a/Formula/newrelic@8.0.rb
+++ b/Formula/newrelic@8.0.rb
@@ -16,13 +16,6 @@ class NewrelicAT80 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_ventura:  "a3dc2936ad8f1a545fe6b49312ceac0d799263aa5375cc4f13b035d812d8ee26"
-    sha256 cellar: :any,                 arm64_monterey: "7a4bf85dbe1038e2d3e163c94381baef1295d07b3d525772e09f850836b65c03"
-    sha256 cellar: :any,                 arm64_big_sur:  "8990f961183223c8f43b42cd0055b95258826ce8e4484f214e48860150ac8091"
-    sha256 cellar: :any,                 ventura:        "fa11b6108a73c9b30bf7b4dcbb50d4723e0122496cf06d25cce022c45f2dfc6e"
-    sha256 cellar: :any,                 monterey:       "643a3c1287de199522276af033bbecc4661d8dd0458396a512f2c4491b624261"
-    sha256 cellar: :any,                 big_sur:        "20f52f3ebc0187b9c499dde86bb8faf709b5aea2e78adfec4e0761b7b9d5038d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "72d21b4b2055aaf5b48282e95503fd3cd0c468e9f07c6164528fb73c7f1e70c4"
   end
 
   # for pcre_compile

--- a/Formula/newrelic@8.1.rb
+++ b/Formula/newrelic@8.1.rb
@@ -8,9 +8,9 @@ class NewrelicAT81 < AbstractPhpExtension
   init
   desc "Newrelic PHP extension"
   homepage "https://github.com/newrelic/newrelic-php-agent"
-  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.4.0.316.tar.gz"
-  version "v10.4.0.316"
-  sha256 "84eee1791051dafbad6627134dd052cc89e6611b175fda7808a65786938591b3"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v11.0.0.13.tar.gz"
+  version "v11.0.0.13"
+  sha256 "69f72541acf03e63a4d7d4a1053857b009279d1c526c9b68ed1338670a9e2cc0"
   head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
   license "Apache-2.0"
 
@@ -50,7 +50,7 @@ class NewrelicAT81 < AbstractPhpExtension
   end
 
   def install
-    inreplace "agent/php_autorum.c", "return (char*)emalloc(len);", "return (char*)emalloc((unsigned)len);"
+    inreplace "agent/config.m4", "-l:libprotobuf-c.a", "-lprotobuf-c"
     inreplace "axiom/Makefile", "AXIOM_CFLAGS += -Wimplicit-fallthrough", "#AXIOM_CFLAGS += -Wimplicit-fallthrough"
     system "make", "daemon"
     system "make", "agent"

--- a/Formula/newrelic@8.1.rb
+++ b/Formula/newrelic@8.1.rb
@@ -16,13 +16,6 @@ class NewrelicAT81 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_ventura:  "4e855dd29873399e69975c65589da82bf1c736a0cd1a255a3cd857d45861c3e3"
-    sha256 cellar: :any,                 arm64_monterey: "6fbe83f17a3ea549317de4c8c75bc0a898637604ac41fb7bb1697b3e3895c9dd"
-    sha256 cellar: :any,                 arm64_big_sur:  "6f73b6b7aca8a79bd584b2f9fdfe5e91e844b6eb79e222b61625f90f19bb8261"
-    sha256 cellar: :any,                 ventura:        "7746347adc42171755a9f28a66a27036ae6e4d8a313b2ff0b3863b4ee757951b"
-    sha256 cellar: :any,                 monterey:       "d03c92f6953c40dab0b07267ed3be2b4fa4db19dcda66d4bf7bc4a539e91336d"
-    sha256 cellar: :any,                 big_sur:        "009d799761230579a009fae0aa5f802422770acd172359c30f7c94196276d93e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bb23f1c07b129b514e33de1275bd14df90f7f756d951e198a7e7b40336489565"
   end
 
   # for pcre_compile

--- a/Formula/newrelic@8.2.rb
+++ b/Formula/newrelic@8.2.rb
@@ -8,9 +8,9 @@ class NewrelicAT82 < AbstractPhpExtension
   init
   desc "Newrelic PHP extension"
   homepage "https://github.com/newrelic/newrelic-php-agent"
-  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.15.0.4.tar.gz"
-  version "v10.15.0.4"
-  sha256 "8ffb3d377ec8632a5a873a1a53614b73027c8a3fbebba29c3aba956635578e01"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v11.0.0.13.tar.gz"
+  version "v11.0.0.13"
+  sha256 "69f72541acf03e63a4d7d4a1053857b009279d1c526c9b68ed1338670a9e2cc0"
   head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
   license "Apache-2.0"
 

--- a/Formula/newrelic@8.2.rb
+++ b/Formula/newrelic@8.2.rb
@@ -16,12 +16,6 @@ class NewrelicAT82 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_sonoma:   "3310b88541000ee3e89b011960755c7984c639289a4330b67efb216c35ec9d71"
-    sha256 cellar: :any,                 arm64_ventura:  "2125a1797b2353b6a3e8d0f6a7fe407d084b9302e08cf034fc5b13ffb4cbdb70"
-    sha256 cellar: :any,                 arm64_monterey: "32efddb693e4b04c9b9495a5eff12c5833e7ea4626e444676cf74d13465b4a99"
-    sha256 cellar: :any,                 ventura:        "22aaa666486e15aa75971ca608570df33b1f65a7812a6d1340d27a8c2a4a2281"
-    sha256 cellar: :any,                 monterey:       "c98db7b14b109df4a52980b79388cd1febc2e2f115411880654577fef208dde8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2591222efe541501d9fb40a25d8db35307f2f87e2ae2bb9383a76a12ddaa67b6"
   end
 
   # for pcre_compile

--- a/Formula/newrelic@8.3.rb
+++ b/Formula/newrelic@8.3.rb
@@ -16,12 +16,6 @@ class NewrelicAT83 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_sonoma:   "9c94a00e5b360e93591bbaa540ff9e20a044d6044e977ac06ae7fe1f2a1164cb"
-    sha256 cellar: :any,                 arm64_ventura:  "925bd33eb7d9a9af666300cf02eb5a87cfd512e0753d293b520510ef18364505"
-    sha256 cellar: :any,                 arm64_monterey: "aa9c1d706b5473ddb5c56cfa301f38baade0a2bf5e0892fa45abfeef5cdea0a0"
-    sha256 cellar: :any,                 ventura:        "511fabf26decc58594be013f1a15176cb345870cd6cffa41550f32b3cf0d9c45"
-    sha256 cellar: :any,                 monterey:       "7373e491fb8ccc7e42a329b5d3c2c1bf0ad94999a832de813bfa047a83f0f588"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a0558afad4cf82689873f5fc5841eb7a1bd2faaa5996502792f568a826aa5cff"
   end
 
   # for pcre_compile

--- a/Formula/newrelic@8.3.rb
+++ b/Formula/newrelic@8.3.rb
@@ -8,9 +8,9 @@ class NewrelicAT83 < AbstractPhpExtension
   init
   desc "Newrelic PHP extension"
   homepage "https://github.com/newrelic/newrelic-php-agent"
-  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v10.15.0.4.tar.gz"
-  version "v10.15.0.4"
-  sha256 "8ffb3d377ec8632a5a873a1a53614b73027c8a3fbebba29c3aba956635578e01"
+  url "https://github.com/newrelic/newrelic-php-agent/archive/refs/tags/v11.0.0.13.tar.gz"
+  version "v11.0.0.13"
+  sha256 "69f72541acf03e63a4d7d4a1053857b009279d1c526c9b68ed1338670a9e2cc0"
   head "https://github.com/newrelic/newrelic-php-agent.git", branch: "main"
   license "Apache-2.0"
 

--- a/Formula/newrelic@8.4.rb
+++ b/Formula/newrelic@8.4.rb
@@ -1,10 +1,10 @@
-# typed: true
+# typed: false
 # frozen_string_literal: true
 
 require File.expand_path("../Abstract/abstract-php-extension", __dir__)
 
 # Class for Newrelic Extension
-class NewrelicAT80 < AbstractPhpExtension
+class NewrelicAT84 < AbstractPhpExtension
   init
   desc "Newrelic PHP extension"
   homepage "https://github.com/newrelic/newrelic-php-agent"
@@ -16,13 +16,12 @@ class NewrelicAT80 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_ventura:  "a3dc2936ad8f1a545fe6b49312ceac0d799263aa5375cc4f13b035d812d8ee26"
-    sha256 cellar: :any,                 arm64_monterey: "7a4bf85dbe1038e2d3e163c94381baef1295d07b3d525772e09f850836b65c03"
-    sha256 cellar: :any,                 arm64_big_sur:  "8990f961183223c8f43b42cd0055b95258826ce8e4484f214e48860150ac8091"
-    sha256 cellar: :any,                 ventura:        "fa11b6108a73c9b30bf7b4dcbb50d4723e0122496cf06d25cce022c45f2dfc6e"
-    sha256 cellar: :any,                 monterey:       "643a3c1287de199522276af033bbecc4661d8dd0458396a512f2c4491b624261"
-    sha256 cellar: :any,                 big_sur:        "20f52f3ebc0187b9c499dde86bb8faf709b5aea2e78adfec4e0761b7b9d5038d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "72d21b4b2055aaf5b48282e95503fd3cd0c468e9f07c6164528fb73c7f1e70c4"
+    sha256 cellar: :any,                 arm64_sonoma:   "9c94a00e5b360e93591bbaa540ff9e20a044d6044e977ac06ae7fe1f2a1164cb"
+    sha256 cellar: :any,                 arm64_ventura:  "925bd33eb7d9a9af666300cf02eb5a87cfd512e0753d293b520510ef18364505"
+    sha256 cellar: :any,                 arm64_monterey: "aa9c1d706b5473ddb5c56cfa301f38baade0a2bf5e0892fa45abfeef5cdea0a0"
+    sha256 cellar: :any,                 ventura:        "511fabf26decc58594be013f1a15176cb345870cd6cffa41550f32b3cf0d9c45"
+    sha256 cellar: :any,                 monterey:       "7373e491fb8ccc7e42a329b5d3c2c1bf0ad94999a832de813bfa047a83f0f588"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a0558afad4cf82689873f5fc5841eb7a1bd2faaa5996502792f568a826aa5cff"
   end
 
   # for pcre_compile
@@ -40,8 +39,8 @@ class NewrelicAT80 < AbstractPhpExtension
       [#{extension}]
       #{extension_type}="#{module_path}"
       newrelic.daemon.location="#{prefix}/daemon"
-      newrelic.daemon.address="/tmp/.newrelic80.sock"
-      newrelic.daemon.port="/tmp/.newrelic80.sock"
+      newrelic.daemon.address="/tmp/.newrelic84.sock"
+      newrelic.daemon.port="/tmp/.newrelic84.sock"
       newrelic.logfile="/var/log/newrelic_php_agent.log"
       newrelic.daemon.logfile="/var/log/newrelic_daemon.log"
     EOS

--- a/Formula/newrelic@8.4.rb
+++ b/Formula/newrelic@8.4.rb
@@ -16,12 +16,6 @@ class NewrelicAT84 < AbstractPhpExtension
 
   bottle do
     root_url "https://ghcr.io/v2/shivammathur/extensions"
-    sha256 cellar: :any,                 arm64_sonoma:   "9c94a00e5b360e93591bbaa540ff9e20a044d6044e977ac06ae7fe1f2a1164cb"
-    sha256 cellar: :any,                 arm64_ventura:  "925bd33eb7d9a9af666300cf02eb5a87cfd512e0753d293b520510ef18364505"
-    sha256 cellar: :any,                 arm64_monterey: "aa9c1d706b5473ddb5c56cfa301f38baade0a2bf5e0892fa45abfeef5cdea0a0"
-    sha256 cellar: :any,                 ventura:        "511fabf26decc58594be013f1a15176cb345870cd6cffa41550f32b3cf0d9c45"
-    sha256 cellar: :any,                 monterey:       "7373e491fb8ccc7e42a329b5d3c2c1bf0ad94999a832de813bfa047a83f0f588"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a0558afad4cf82689873f5fc5841eb7a1bd2faaa5996502792f568a826aa5cff"
   end
 
   # for pcre_compile

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 | `memcached`     | `PHP 5.6` to `PHP 8.4` |
 | `mongodb`       | `PHP 5.6` to `PHP 8.4` |
 | `msgpack`       | `PHP 5.6` to `PHP 8.4` |
-| `newrelic`      | `PHP 7.4` to `PHP 8.3` |
+| `newrelic`      | `PHP 7.4` to `PHP 8.4` |
 | `opentelemetry` | `PHP 8.0` to `PHP 8.4` |
 | `pcov`          | `PHP 7.1` to `PHP 8.4` |
 | `pdo_sqlsrv`    | `PHP 7.0` to `PHP 8.4` |


### PR DESCRIPTION
---
name: ⚙ Improvement and 🎉 New Feature
about: NewRelic PHP agent version update & added support for 8.4
labels: enhancement

---
### Description

Updating NewRelic's formulas PHP agent to latest released version from https://github.com/newrelic/newrelic-php-agent/tags and also added support for PHP 8.4
