### PR TITLE
Update ext-mongodb to 1.20.0

### DIFF
--- a/Formula/mongodb@5.6.rb
+++ b/Formula/mongodb@5.6.rb
@@ -11,7 +11,7 @@ class MongodbAT56 < AbstractPhpExtension
   url "https://pecl.php.net/get/mongodb-1.7.5.tgz"
   sha256 "e48a07618c0ae8be628299991b5f481861c891a22544a2365a63361cc181c379"
   revision 2
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.7"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@7.0.rb
+++ b/Formula/mongodb@7.0.rb
@@ -11,7 +11,7 @@ class MongodbAT70 < AbstractPhpExtension
   url "https://pecl.php.net/get/mongodb-1.9.2.tgz"
   sha256 "95e832c5d48ae6e947bdc79f35a9f8f0bbd518f4aa00f1cef6c9eafbae02187d"
   revision 2
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.9"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@7.1.rb
+++ b/Formula/mongodb@7.1.rb
@@ -11,7 +11,7 @@ class MongodbAT71 < AbstractPhpExtension
   url "https://pecl.php.net/get/mongodb-1.11.1.tgz"
   sha256 "838a5050de50d51f959026bd8cec7349d8af37058c0fe07295a0bc960a82d7ef"
   revision 2
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.11"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@7.2.rb
+++ b/Formula/mongodb@7.2.rb
@@ -10,7 +10,7 @@ class MongodbAT72 < AbstractPhpExtension
   homepage "https://github.com/mongodb/mongo-php-driver"
   url "https://pecl.php.net/get/mongodb-1.16.2.tgz"
   sha256 "d630cf32a73b6e5e05d2806782d35e06d24b7d5c83cfec08239549e6b6a600b2"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.16"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@7.3.rb
+++ b/Formula/mongodb@7.3.rb
@@ -10,7 +10,7 @@ class MongodbAT73 < AbstractPhpExtension
   homepage "https://github.com/mongodb/mongo-php-driver"
   url "https://pecl.php.net/get/mongodb-1.16.2.tgz"
   sha256 "d630cf32a73b6e5e05d2806782d35e06d24b7d5c83cfec08239549e6b6a600b2"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.16"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@7.4.rb
+++ b/Formula/mongodb@7.4.rb
@@ -8,9 +8,9 @@ class MongodbAT74 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.20"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@8.0.rb
+++ b/Formula/mongodb@8.0.rb
@@ -8,9 +8,9 @@ class MongodbAT80 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.20"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@8.1.rb
+++ b/Formula/mongodb@8.1.rb
@@ -8,9 +8,9 @@ class MongodbAT81 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.x"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@8.2.rb
+++ b/Formula/mongodb@8.2.rb
@@ -8,9 +8,9 @@ class MongodbAT82 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.x"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@8.3.rb
+++ b/Formula/mongodb@8.3.rb
@@ -8,9 +8,9 @@ class MongodbAT83 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git", branch: "master"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.x"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/mongodb@8.4.rb
+++ b/Formula/mongodb@8.4.rb
@@ -8,9 +8,9 @@ class MongodbAT84 < AbstractPhpExtension
   init
   desc "Mongodb PHP extension"
   homepage "https://github.com/mongodb/mongo-php-driver"
-  url "https://pecl.php.net/get/mongodb-1.19.4.tgz"
-  sha256 "57c168b24a7d07f73367e4b134eb911ad1170ba7d203bc475f6ef1b860c16701"
-  head "https://github.com/mongodb/mongo-php-driver.git", branch: "master"
+  url "https://pecl.php.net/get/mongodb-1.20.0.tgz"
+  sha256 "01e87973fe7e54aac52054ec4a99cdd439ed5c01f7e5b8ea0a57031850d8e75a"
+  head "https://github.com/mongodb/mongo-php-driver.git", branch: "v1.x"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
Fixes #4227. This PR updates to MongoDB 1.20.0 on PHP >= 7.4. I've also updated the branch names as we've moved away from a single master branch.

Note: we're currently working on a 2.0 release, which will drop functionality currently present in 1.x. I'm not sure what the best way is to offer 1.x and 2.x at the same time, so that's something we'll want to figure out. The release is still a few weeks out though.