### PR TITLE
Add xhprof extension formulae

### DIFF
--- a/Formula/xhprof@7.2.rb
+++ b/Formula/xhprof@7.2.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT72 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@7.3.rb
+++ b/Formula/xhprof@7.3.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT73 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@7.4.rb
+++ b/Formula/xhprof@7.4.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT74 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@8.1.rb
+++ b/Formula/xhprof@8.1.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT81 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@8.2.rb
+++ b/Formula/xhprof@8.2.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT82 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@8.3.rb
+++ b/Formula/xhprof@8.3.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT83 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/Formula/xhprof@8.4.rb
+++ b/Formula/xhprof@8.4.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+require File.expand_path("../Abstract/abstract-php-extension", __dir__)
+
+class XhprofAT84 < AbstractPhpExtension
+  init
+  desc "Hierarchical Profiler for PHP"
+  homepage "https://github.com/longxinH/xhprof"
+  url "https://pecl.php.net/get/xhprof-2.3.10.tgz"
+  sha256 "251aee99c2726ebc6126e1ff0bb2db6e2d5fd22056aa335e84db9f1055d59d95"
+  license "Apache-2.0"
+
+  def install
+    Dir.chdir "xhprof-#{version}" do
+      safe_phpize
+      system "./configure", "--prefix=#{prefix}", phpconfig
+      system "make"
+      prefix.install "modules/#{extension}.so"
+    end
+    write_config_file
+  end
+end

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 | `vld`           | `PHP 5.6` to `PHP 8.3` |
 | `xdebug`        | `PHP 5.6` to `PHP 8.5` |
 | `xdebug2`       | `PHP 7.2` to `PHP 7.4` |
+| `xhprof`        | `PHP 7.2` to `PHP 8.4` |
 | `xlswriter`     | `PHP 7.0` to `PHP 8.5` |
 | `yaml`          | `PHP 5.6` to `PHP 8.5` |
 | `zmq`           | `PHP 5.6` to `PHP 8.5` |
@@ -243,6 +244,7 @@ This project is also generously supported by many other users and organisations 
 - [swoole/swoole-src](https://github.com/swoole/swoole-src "Swoole")
 - [websupport-sk/pecl-memcache](https://github.com/websupport-sk/pecl-memcache "Memcache")
 - [xdebug/xdebug](https://github.com/xdebug/xdebug "Xdebug")
+- [longxinH/xhprof](https://github.com/longxinH/xhprof "xhprof")
 - [xlswriter](https://github.com/viest/php-ext-xlswriter.git "xlswriter")
 - [zeromq/php-zmq](https://github.com/zeromq/php-zmq "ZMQ")
 - [newrelic/newrelic-php-agent](https://github.com/newrelic/newrelic-php-agent "newrelic")


### PR DESCRIPTION
### Description

This PR adds support for the **`xhprof` PHP extension** across multiple PHP versions.  
Specifically, it introduces new formulae for PHP 7.2-8.4

This PR closes #3529.