### PR TITLE
Add missed UI installation for spx

### DIFF
--- a/Formula/spx@5.6.rb
+++ b/Formula/spx@5.6.rb
@@ -33,10 +33,12 @@ class SpxAT56 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@7.0.rb
+++ b/Formula/spx@7.0.rb
@@ -33,10 +33,12 @@ class SpxAT70 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@7.1.rb
+++ b/Formula/spx@7.1.rb
@@ -33,10 +33,12 @@ class SpxAT71 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@7.2.rb
+++ b/Formula/spx@7.2.rb
@@ -33,10 +33,12 @@ class SpxAT72 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@7.3.rb
+++ b/Formula/spx@7.3.rb
@@ -33,10 +33,12 @@ class SpxAT73 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@7.4.rb
+++ b/Formula/spx@7.4.rb
@@ -33,10 +33,12 @@ class SpxAT74 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.0.rb
+++ b/Formula/spx@8.0.rb
@@ -33,10 +33,12 @@ class SpxAT80 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.1.rb
+++ b/Formula/spx@8.1.rb
@@ -33,10 +33,12 @@ class SpxAT81 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.2.rb
+++ b/Formula/spx@8.2.rb
@@ -33,10 +33,12 @@ class SpxAT82 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.3.rb
+++ b/Formula/spx@8.3.rb
@@ -33,10 +33,12 @@ class SpxAT83 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.4.rb
+++ b/Formula/spx@8.4.rb
@@ -33,10 +33,12 @@ class SpxAT84 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.5.rb
+++ b/Formula/spx@8.5.rb
@@ -33,11 +33,13 @@ class SpxAT85 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     inreplace "src/php_spx.h", /ZEND_MODULE_API_NO.*/, "0"
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end

--- a/Formula/spx@8.6.rb
+++ b/Formula/spx@8.6.rb
@@ -33,11 +33,13 @@ class SpxAT86 < AbstractPhpExtension
     args = %W[
       --enable-spx
       --with-zlib-dir=#{Formula["zlib"].opt_prefix}
+      --with-spx-assets-dir=#{pkgshare}
     ]
     inreplace "src/php_spx.h", /ZEND_MODULE_API_NO.*/, "0"
     safe_phpize
     system "./configure", "--prefix=#{prefix}", phpconfig, *args
     system "make"
+    system "make", "install-spx-ui-assets"
     prefix.install "modules/#{extension}.so"
     write_config_file
   end


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: Missing UI for SPX
labels: bug

---

## A Pull Request should be associated with an Issue.

> If you're fixing a bug, adding a new feature or improving something please provide the details in Issues,
> so that the development can be pointed in the intended direction.

Related issue: #5651

### Description

- Add installation step for UI => `system "make install-spx-ui-assets"`
- Change path for copy/paste UI command => `--with-spx-assets-dir=#{pkgshare}`
- Without this param it wants to copy/paste UI into `php-config --prefix` (`/opt/homebrew/Cellar/php@8.4/8.4.16_1`), but this is not allowed to do. It endups with "Permission denied" errors.
- Result is that UI is avaiable and path to UI (`php -i | grep spx.http_ui_assets_dir`) exists (`/opt/homebrew/Cellar/spx@8.4/0.4.22/share/spx@8.4/web-ui`)
