### PR TITLE
firebird-client@3 3.0.14

### DIFF
--- a/Formula/firebird-client@3.rb
+++ b/Formula/firebird-client@3.rb
@@ -6,8 +6,8 @@ class FirebirdClientAT3 < Formula
   env :std if OS.linux?
   desc "Client libraries and headers for Firebird database"
   homepage "https://firebirdsql.org"
-  url "https://github.com/FirebirdSQL/firebird/archive/refs/tags/v3.0.13.tar.gz"
-  sha256 "7a5e378d4b65f1b4cb03a8da539b72ddc5033f566f6cb2f72184ea1498746b30"
+  url "https://github.com/FirebirdSQL/firebird/archive/refs/tags/v3.0.14.tar.gz"
+  sha256 "cd56ccb5801be0d26e62cd7bbbe161c9852a7c181e72ead4036ed75467135b9a"
   # License references:
   # 1. https://firebirdsql.org/en/interbase-public-license
   # 2. https://www.firebirdsql.org/en/initial-developer-s-public-license-version-1-0/

--- a/Formula/firebird-client@3.rb
+++ b/Formula/firebird-client@3.rb
@@ -61,6 +61,18 @@ class FirebirdClientAT3 < Formula
 "VCPKG_TRIPLET="
       end
     end
+
+    # Firebird's POSIX make rules incorrectly compile root-level C++ sources
+    # (like examples/udr/*.cpp) with CC/WCFLAGS. Modern Homebrew superenv adds
+    # C-only flags such as -std=gnu23 to CC, which breaks those C++ objects.
+    make_rules = buildpath/"builds/posix/make.rules"
+    if make_rules.exist?
+      content = make_rules.read
+      content.gsub!(%r{(\$\(OBJ\)/%\.o: \$\(ROOT\)/%\.cpp\n)\t\$\(CC\) \$\(WCFLAGS\)},
+                    "\\1\t$(CXX) $(WCXXFLAGS)")
+      make_rules.atomic_write(content)
+    end
+
     if OS.mac?
       src_darwin_defaults = buildpath/"builds/posix/darwin.defaults"
       if src_darwin_defaults.exist?


### PR DESCRIPTION
## Summary
- bump firebird-client@3 from 3.0.13 to 3.0.14

## Testing
- brew livecheck --autobump --json shivammathur/extensions/firebird-client@3